### PR TITLE
[FEAT-3] Form 웹 접근성 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "@tanstack/react-query": "^5.84.2",
         "jotai": "^2.13.1",
         "lucide-react": "^0.453.0",
-        "next": "15.4.6",
-        "react": "19.1.0",
-        "react-dom": "19.1.0",
+        "next": "15.4.8",
+        "react": "19.1.2",
+        "react-dom": "19.1.2",
         "react-hook-form": "^7.62.0",
         "zod": "^4.0.17"
       },
@@ -1056,9 +1056,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.6.tgz",
-      "integrity": "sha512-yHDKVTcHrZy/8TWhj0B23ylKv5ypocuCwey9ZqPyv4rPdUdRzpGCkSi03t04KBPyU96kxVtUqx6O3nE1kpxASQ==",
+      "version": "15.4.8",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.8.tgz",
+      "integrity": "sha512-LydLa2MDI1NMrOFSkO54mTc8iIHSttj6R6dthITky9ylXV2gCGi0bHQjVCtLGRshdRPjyh2kXbxJukDtBWQZtQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1072,9 +1072,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.6.tgz",
-      "integrity": "sha512-667R0RTP4DwxzmrqTs4Lr5dcEda9OxuZsVFsjVtxVMVhzSpo6nLclXejJVfQo2/g7/Z9qF3ETDmN3h65mTjpTQ==",
+      "version": "15.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.8.tgz",
+      "integrity": "sha512-Pf6zXp7yyQEn7sqMxur6+kYcywx5up1J849psyET7/8pG2gQTVMjU3NzgIt8SeEP5to3If/SaWmaA6H6ysBr1A==",
       "cpu": [
         "arm64"
       ],
@@ -1088,9 +1088,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.6.tgz",
-      "integrity": "sha512-KMSFoistFkaiQYVQQnaU9MPWtp/3m0kn2Xed1Ces5ll+ag1+rlac20sxG+MqhH2qYWX1O2GFOATQXEyxKiIscg==",
+      "version": "15.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.8.tgz",
+      "integrity": "sha512-xla6AOfz68a6kq3gRQccWEvFC/VRGJmA/QuSLENSO7CZX5WIEkSz7r1FdXUjtGCQ1c2M+ndUAH7opdfLK1PQbw==",
       "cpu": [
         "x64"
       ],
@@ -1104,9 +1104,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.6.tgz",
-      "integrity": "sha512-PnOx1YdO0W7m/HWFeYd2A6JtBO8O8Eb9h6nfJia2Dw1sRHoHpNf6lN1U4GKFRzRDBi9Nq2GrHk9PF3Vmwf7XVw==",
+      "version": "15.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.8.tgz",
+      "integrity": "sha512-y3fmp+1Px/SJD+5ntve5QLZnGLycsxsVPkTzAc3zUiXYSOlTPqT8ynfmt6tt4fSo1tAhDPmryXpYKEAcoAPDJw==",
       "cpu": [
         "arm64"
       ],
@@ -1120,9 +1120,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.6.tgz",
-      "integrity": "sha512-XBbuQddtY1p5FGPc2naMO0kqs4YYtLYK/8aPausI5lyOjr4J77KTG9mtlU4P3NwkLI1+OjsPzKVvSJdMs3cFaw==",
+      "version": "15.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.8.tgz",
+      "integrity": "sha512-DX/L8VHzrr1CfwaVjBQr3GWCqNNFgyWJbeQ10Lx/phzbQo3JNAxUok1DZ8JHRGcL6PgMRgj6HylnLNndxn4Z6A==",
       "cpu": [
         "arm64"
       ],
@@ -1136,9 +1136,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.6.tgz",
-      "integrity": "sha512-+WTeK7Qdw82ez3U9JgD+igBAP75gqZ1vbK6R8PlEEuY0OIe5FuYXA4aTjL811kWPf7hNeslD4hHK2WoM9W0IgA==",
+      "version": "15.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.8.tgz",
+      "integrity": "sha512-9fLAAXKAL3xEIFdKdzG5rUSvSiZTLLTCc6JKq1z04DR4zY7DbAPcRvNm3K1inVhTiQCs19ZRAgUerHiVKMZZIA==",
       "cpu": [
         "x64"
       ],
@@ -1152,9 +1152,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.6.tgz",
-      "integrity": "sha512-XP824mCbgQsK20jlXKrUpZoh/iO3vUWhMpxCz8oYeagoiZ4V0TQiKy0ASji1KK6IAe3DYGfj5RfKP6+L2020OQ==",
+      "version": "15.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.8.tgz",
+      "integrity": "sha512-s45V7nfb5g7dbS7JK6XZDcapicVrMMvX2uYgOHP16QuKH/JA285oy6HcxlKqwUNaFY/UC6EvQ8QZUOo19cBKSA==",
       "cpu": [
         "x64"
       ],
@@ -1168,9 +1168,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.6.tgz",
-      "integrity": "sha512-FxrsenhUz0LbgRkNWx6FRRJIPe/MI1JRA4W4EPd5leXO00AZ6YU8v5vfx4MDXTvN77lM/EqsE3+6d2CIeF5NYg==",
+      "version": "15.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.8.tgz",
+      "integrity": "sha512-KjgeQyOAq7t/HzAJcWPGA8X+4WY03uSCZ2Ekk98S9OgCFsb6lfBE3dbUzUuEQAN2THbwYgFfxX2yFTCMm8Kehw==",
       "cpu": [
         "arm64"
       ],
@@ -1184,9 +1184,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.6.tgz",
-      "integrity": "sha512-T4ufqnZ4u88ZheczkBTtOF+eKaM14V8kbjud/XrAakoM5DKQWjW09vD6B9fsdsWS2T7D5EY31hRHdta7QKWOng==",
+      "version": "15.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.8.tgz",
+      "integrity": "sha512-Exsmf/+42fWVnLMaZHzshukTBxZrSwuuLKFvqhGHJ+mC1AokqieLY/XzAl3jc/CqhXLqLY3RRjkKJ9YnLPcRWg==",
       "cpu": [
         "x64"
       ],
@@ -4613,12 +4613,13 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.4.6.tgz",
-      "integrity": "sha512-us++E/Q80/8+UekzB3SAGs71AlLDsadpFMXVNM/uQ0BMwsh9m3mr0UNQIfjKed8vpWXsASe+Qifrnu1oLIcKEQ==",
+      "version": "15.4.8",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.4.8.tgz",
+      "integrity": "sha512-jwOXTz/bo0Pvlf20FSb6VXVeWRssA2vbvq9SdrOPEg9x8E1B27C2rQtvriAn600o9hH61kjrVRexEffv3JybuA==",
+      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.4.6",
+        "@next/env": "15.4.8",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -4631,14 +4632,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.4.6",
-        "@next/swc-darwin-x64": "15.4.6",
-        "@next/swc-linux-arm64-gnu": "15.4.6",
-        "@next/swc-linux-arm64-musl": "15.4.6",
-        "@next/swc-linux-x64-gnu": "15.4.6",
-        "@next/swc-linux-x64-musl": "15.4.6",
-        "@next/swc-win32-arm64-msvc": "15.4.6",
-        "@next/swc-win32-x64-msvc": "15.4.6",
+        "@next/swc-darwin-arm64": "15.4.8",
+        "@next/swc-darwin-x64": "15.4.8",
+        "@next/swc-linux-arm64-gnu": "15.4.8",
+        "@next/swc-linux-arm64-musl": "15.4.8",
+        "@next/swc-linux-x64-gnu": "15.4.8",
+        "@next/swc-linux-x64-musl": "15.4.8",
+        "@next/swc-win32-arm64-msvc": "15.4.8",
+        "@next/swc-win32-x64-msvc": "15.4.8",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -5066,24 +5067,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.2.tgz",
+      "integrity": "sha512-MdWVitvLbQULD+4DP8GYjZUrepGW7d+GQkNVqJEzNxE+e9WIa4egVFE/RDfVb1u9u/Jw7dNMmPB4IqxzbFYJ0w==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.2.tgz",
+      "integrity": "sha512-dEoydsCp50i7kS1xHOmPXq4zQYoGWedUsvqv9H6zdif2r7yLHygyfP9qou71TulRN0d6ng9EbRVsQhSqfUc19g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^19.1.2"
       }
     },
     "node_modules/react-hook-form": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "@tanstack/react-query": "^5.84.2",
     "jotai": "^2.13.1",
     "lucide-react": "^0.453.0",
-    "next": "15.4.6",
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
+    "next": "15.4.8",
+    "react": "19.1.2",
+    "react-dom": "19.1.2",
     "react-hook-form": "^7.62.0",
     "zod": "^4.0.17"
   },

--- a/src/components/rhf-inputs/rhf-segmented.tsx
+++ b/src/components/rhf-inputs/rhf-segmented.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react'
 import { FieldValues, Path, useFormContext, useWatch } from 'react-hook-form'
 import {
   errorText,
@@ -21,6 +22,7 @@ type Props<T extends FieldValues, V extends string> = {
 
 export function RHFSegmented<T extends FieldValues, V extends string>(props: Props<T, V>) {
   const { name, label, options, onChange } = props
+  const labelId = useId()
   const {
     register,
     control,
@@ -32,8 +34,10 @@ export function RHFSegmented<T extends FieldValues, V extends string>(props: Pro
 
   return (
     <div css={fieldStyle}>
-      <p css={labelStyle}>{label}</p>
-      <div css={segGroup}>
+      <p css={labelStyle} id={labelId}>
+        {label}
+      </p>
+      <div css={segGroup} role="radiogroup" aria-labelledby={labelId}>
         {options.map((opt) => (
           <label key={String(opt.value)} css={segItem}>
             <input

--- a/src/components/stepper/step-navigator.tsx
+++ b/src/components/stepper/step-navigator.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from 'react'
+import { useCallback } from 'react'
+import type { KeyboardEvent, ReactNode } from 'react'
 import type { FieldValues, SubmitHandler, UseFormReturn } from 'react-hook-form'
 
 import { StepProgress } from '@/components/stepper/step-progress'
@@ -27,9 +28,54 @@ export function StepNavigator<TValues extends FieldValues, TComponentId extends 
 }: StepNavigatorProps<TValues, TComponentId>) {
   const { handleSubmit } = methods
   const { step, state, meta, actions } = useStepController({ steps, methods })
+  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLFormElement>) => {
+    if (event.key !== 'Enter') {
+      return
+    }
+
+    const target = event.target as HTMLElement
+    if (!target || target.tagName === 'TEXTAREA') {
+      return
+    }
+
+    const form = event.currentTarget
+    const focusableElements = Array.from(
+      form.querySelectorAll<HTMLElement>('input, select, textarea, button, [tabindex]')
+    ).filter((element) => {
+      if (element.hasAttribute('disabled')) return false
+      if (element.getAttribute('aria-hidden') === 'true') return false
+      if (element.tabIndex < 0) return false
+      if (element.tagName === 'INPUT') {
+        const input = element as HTMLInputElement
+        if (input.type === 'hidden' || input.type === 'button' || input.type === 'submit') {
+          return false
+        }
+      }
+      return true
+    })
+
+    const currentIndex = focusableElements.findIndex((element) => element === target)
+    if (currentIndex === -1) {
+      return
+    }
+
+    const nextElement = focusableElements.slice(currentIndex + 1).find((element) => {
+      if (element.tagName === 'BUTTON') return false
+      if (element.tagName === 'INPUT') {
+        const input = element as HTMLInputElement
+        if (input.type === 'radio') return false
+      }
+      return true
+    })
+
+    if (nextElement) {
+      event.preventDefault()
+      nextElement.focus()
+    }
+  }, [])
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} css={stepFormLayout}>
+    <form onSubmit={handleSubmit(onSubmit)} onKeyDown={handleKeyDown} css={stepFormLayout}>
       <StepProgress title={title} steps={meta.navigation} state={state} actions={actions} />
 
       <main css={stepMainArea}>

--- a/src/features/book-form/hooks/use-multi-step-form.ts
+++ b/src/features/book-form/hooks/use-multi-step-form.ts
@@ -70,18 +70,18 @@ export function useStepController<TValues extends FieldValues, TComponentId exte
       const fieldName = String(field)
 
       if (fieldName === 'quotes') {
-        const quotes = getValues('quotes' as Path<TValues>) as unknown[]
+        const quotes = getValues('quotes' as Path<TValues>)
         if (Array.isArray(quotes) && quotes.length > 0) {
           const firstQuote = quotes[0]
           if (firstQuote && typeof firstQuote === 'object') {
             if ('content' in firstQuote) {
-              return 'quotes.0.content' as Path<TValues>
+              return 'quotes.0.content'
             }
           }
         }
       }
 
-      return fieldName as Path<TValues>
+      return fieldName
     },
     [getValues]
   )
@@ -92,7 +92,7 @@ export function useStepController<TValues extends FieldValues, TComponentId exte
   }, [])
 
   useEffect(() => {
-    const fields = steps[currentIndex]?.fields as Path<TValues>[] | undefined
+    const fields = steps[currentIndex]?.fields
     if (!fields || fields.length === 0) return
 
     const focusable = toFocusablePath(fields[0])
@@ -101,7 +101,7 @@ export function useStepController<TValues extends FieldValues, TComponentId exte
 
   const clearStepErrors = useCallback(
     (index: number) => {
-      const fields = steps[index]?.fields as Path<TValues>[] | undefined
+      const fields = steps[index]?.fields
       if (!fields || fields.length === 0) return
       clearErrors(fields)
     },
@@ -117,7 +117,7 @@ export function useStepController<TValues extends FieldValues, TComponentId exte
         return true
       }
 
-      const fields = (currentStep?.fields ?? []) as Path<TValues>[]
+      const fields = currentStep?.fields ?? []
       const schema = currentStep?.schema
 
       if (schema) {

--- a/src/features/book-form/hooks/use-multi-step-form.ts
+++ b/src/features/book-form/hooks/use-multi-step-form.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { FieldValues, Path, UseFormReturn } from 'react-hook-form'
 import { z } from 'zod'
 
@@ -40,7 +40,65 @@ export function useStepController<TValues extends FieldValues, TComponentId exte
 }: UseStepControllerOptions<TValues, TComponentId>) {
   const [currentIndex, setCurrentIndex] = useState(0)
   const totalSteps = steps.length
-  const { trigger, getValues, setError, clearErrors } = methods
+  const { trigger, getValues, setError, clearErrors, setFocus } = methods
+
+  const focusField = useCallback(
+    (field?: Path<TValues> | string) => {
+      if (!field) return
+      const focusTarget = String(field) as Path<TValues>
+      const focusExecutor =
+        typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
+          ? window.requestAnimationFrame.bind(window)
+          : (cb: FrameRequestCallback) => {
+              setTimeout(() => cb(Date.now()), 0)
+            }
+
+      focusExecutor(() => {
+        try {
+          setFocus(focusTarget, { shouldSelect: true })
+        } catch (error) {
+          console.warn('Failed to focus field', focusTarget, error)
+        }
+      })
+    },
+    [setFocus]
+  )
+
+  const toFocusablePath = useCallback(
+    (field?: Path<TValues> | string) => {
+      if (!field) return undefined
+      const fieldName = String(field)
+
+      if (fieldName === 'quotes') {
+        const quotes = getValues('quotes' as Path<TValues>) as unknown[]
+        if (Array.isArray(quotes) && quotes.length > 0) {
+          const firstQuote = quotes[0]
+          if (firstQuote && typeof firstQuote === 'object') {
+            if ('content' in firstQuote) {
+              return 'quotes.0.content' as Path<TValues>
+            }
+          }
+        }
+      }
+
+      return fieldName as Path<TValues>
+    },
+    [getValues]
+  )
+
+  const scrollToTop = useCallback(() => {
+    if (typeof window === 'undefined') return
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [])
+
+  useEffect(() => {
+    const fields = steps[currentIndex]?.fields as Path<TValues>[] | undefined
+    if (!fields || fields.length === 0) return
+
+    const focusable = toFocusablePath(fields[0])
+    focusField(focusable)
+  }, [currentIndex, focusField, steps, toFocusablePath])
+
   const clearStepErrors = useCallback(
     (index: number) => {
       const fields = steps[index]?.fields as Path<TValues>[] | undefined
@@ -70,8 +128,12 @@ export function useStepController<TValues extends FieldValues, TComponentId exte
         if (!result.success) {
           const issues = result.error.issues
           const fieldToMessage: Record<string, string> = {}
+          let firstIssuePath: string | undefined
           issues.forEach((issue) => {
             const key = issue.path.join('.')
+            if (!firstIssuePath && key) {
+              firstIssuePath = key
+            }
             if (key && !fieldToMessage[key]) {
               fieldToMessage[key] = issue.message
             }
@@ -80,15 +142,31 @@ export function useStepController<TValues extends FieldValues, TComponentId exte
             const name = fieldName as Path<TValues>
             if (message) setError(name, { type: 'manual', message })
           })
+          if (firstIssuePath) {
+            const focusable = toFocusablePath(firstIssuePath)
+            focusField(focusable)
+          }
           return false
         }
         return true
       }
 
-      if (fields.length > 0) return trigger(fields, { shouldFocus: true })
-      return trigger(undefined, { shouldFocus: true })
+      if (fields.length > 0) {
+        const isValid = await trigger(fields, { shouldFocus: true })
+        if (!isValid) {
+          const firstField = toFocusablePath(fields[0])
+          focusField(firstField)
+        }
+        return isValid
+      }
+      const isValid = await trigger(undefined, { shouldFocus: true })
+      if (!isValid) {
+        const focusable = toFocusablePath(steps[index]?.fields?.[0])
+        focusField(focusable)
+      }
+      return isValid
     },
-    [steps, trigger, getValues, setError, clearErrors]
+    [clearErrors, focusField, getValues, steps, toFocusablePath, trigger, setError]
   )
 
   const goNext = useCallback(async () => {
@@ -96,14 +174,21 @@ export function useStepController<TValues extends FieldValues, TComponentId exte
     const ok = await validateStep(currentIndex)
     if (!ok) return
     clearStepErrors(currentIndex)
-    setCurrentIndex((prev) => Math.min(prev + 1, totalSteps - 1))
-  }, [clearStepErrors, currentIndex, totalSteps, validateStep])
+    setCurrentIndex((prev) => {
+      const nextIndex = Math.min(prev + 1, totalSteps - 1)
+      if (nextIndex !== prev) {
+        scrollToTop()
+      }
+      return nextIndex
+    })
+  }, [clearStepErrors, currentIndex, totalSteps, validateStep, scrollToTop])
 
   const goPrev = useCallback(() => {
     if (currentIndex <= 0) return
     clearStepErrors(currentIndex)
     setCurrentIndex((prev) => Math.max(prev - 1, 0))
-  }, [clearStepErrors, currentIndex])
+    scrollToTop()
+  }, [clearStepErrors, currentIndex, scrollToTop])
 
   const goTo = useCallback(
     async (next: number) => {
@@ -121,9 +206,13 @@ export function useStepController<TValues extends FieldValues, TComponentId exte
       }
 
       clearStepErrors(currentIndex)
-      setCurrentIndex(next)
+      setCurrentIndex((prev) => {
+        if (prev === next) return prev
+        scrollToTop()
+        return next
+      })
     },
-    [allowFutureClick, clearStepErrors, currentIndex, totalSteps, validateStep]
+    [allowFutureClick, clearStepErrors, currentIndex, scrollToTop, totalSteps, validateStep]
   )
 
   const state: StepState = useMemo(

--- a/src/features/book-form/multi-step-form.tsx
+++ b/src/features/book-form/multi-step-form.tsx
@@ -66,6 +66,7 @@ export default function MultiStepForm() {
   const methods = useForm<FormValues>({
     resolver: zodResolver(formSchema),
     mode: 'onChange',
+    shouldFocusError: true,
     defaultValues: {
       status: ReadingStatus.WANT,
       reflection: '',

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,15 +2,19 @@ import type { AppProps } from 'next/app'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useState } from 'react'
 import { CacheProvider, ThemeProvider } from '@emotion/react'
+import type { EmotionCache } from '@emotion/cache'
 import createEmotionCache from '@/lib/create-emotion-cache'
 import { appTheme } from '@/styles/theme'
 import { GlobalStyles } from '@/styles/globals'
 
 const clientSideEmotionCache = createEmotionCache()
 
-export default function MyApp({ Component, pageProps }: AppProps) {
+export interface MyAppProps extends AppProps {
+  emotionCache?: EmotionCache
+}
+
+export default function MyApp({ Component, pageProps, emotionCache = clientSideEmotionCache }: MyAppProps) {
   const [queryClient] = useState(() => new QueryClient())
-  const [emotionCache] = useState(clientSideEmotionCache)
 
   return (
     <CacheProvider value={emotionCache}>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,7 +1,8 @@
 import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document'
 import createEmotionServer from '@emotion/server/create-instance'
-import { CacheProvider } from '@emotion/react'
 import createEmotionCache from '@/lib/create-emotion-cache'
+import { MyAppProps } from './_app'
+import { ComponentType, ComponentProps } from 'react'
 
 export default class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
@@ -11,13 +12,9 @@ export default class MyDocument extends Document {
 
     ctx.renderPage = () =>
       originalRenderPage({
-        enhanceApp: (App) =>
+        enhanceApp: (App: ComponentType<ComponentProps<ComponentType<MyAppProps>>>) =>
           function EnhanceApp(props) {
-            return (
-              <CacheProvider value={cache}>
-                <App {...props} />
-              </CacheProvider>
-            )
+            return <App emotionCache={cache} {...props} />
           },
       })
 

--- a/src/styles/form-styles.ts
+++ b/src/styles/form-styles.ts
@@ -124,16 +124,28 @@ export const segGroup = (theme: Theme) => css`
   }
 `
 
-export const segItem = css`
+export const segItem = (theme: Theme) => css`
   display: block;
   flex: 1;
+  position: relative;
+
+  input:focus-visible + span {
+    outline: 2px solid ${theme.color.focus};
+    outline-offset: 3px;
+    border-radius: ${theme.radius.md}px;
+    box-sizing: border-box;
+  }
 `
 export const visuallyHidden = css`
   position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-  pointer-events: none;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 `
 
 export const segButton = (theme: Theme) => css`
@@ -148,6 +160,7 @@ export const segButton = (theme: Theme) => css`
   font-size: 14px;
   font-weight: 600;
   line-height: 20px;
+  cursor: pointer;
   transition:
     background 0.15s,
     border-color 0.15s,

--- a/src/styles/step-styles.ts
+++ b/src/styles/step-styles.ts
@@ -126,7 +126,6 @@ export const stepMainArea = (t: Theme) => css`
   display: flex;
   flex-direction: column;
   min-height: 0;
-  overflow-y: auto;
   padding: ${t.spacing(3)} 0 ${t.spacing(10)};
   scroll-padding-top: ${t.spacing(4)};
   -ms-overflow-style: none;


### PR DESCRIPTION
### 📑 개요
Multi-step Form의 웹 접근성 및 사용성을 개선하고, SSR 환경에서의 스타일 깜빡임(FOUC) 현상을 해결했습니다.
- 관련 이슈: #3 
### 🔑 주요 구현
**1. FOUC 해결**
- `_document`에서 생성한 `emotionCache`를 `_app`의 Props로 직접 주입하여, 서버에서 생성된 스타일이 클라이언트에 정상적으로 적용되도록 수정했습니다.

**2. UX 및 웹 접근성 개선**
- **오토 포커스**: 유효성 검사 실패 시, 첫 번째 에러가 발생한 필드(Field Array 포함)로 포커스가 자동 이동합니다.
- **키보드 내비게이션**: 폼 입력 중 `Enter` 키 입력 시 즉시 제출(Submit)되는 것을 막고, 다음 필드로 포커스를 이동시켜 오작동을 방지했습니다.
- **접근성 강화**: 라디오 그룹(`RHFSegmented`)에 `aria-labelledby` 속성을 적용하고, 포커스 스타일(`outline`)을 추가했습니다.
- **스크롤 보정**: 스텝 이동 시 스크롤 위치를 최상단으로 초기화하여 사용자 경험을 개선했습니다.

### 🤔 고민했던 지점
**범용적인 포커스 관리 로직과 타입 안전성**
`step-navigator`와 `use-multi-step-form`에서 다양한 형태의 Input(특히 Field Array나 커스텀 컴포넌트)의 에러 필드를 추적하고 포커싱하는 기능을 구현하는 과정에서 고민이 있었습니다.

최대한 범용적으로 동작하게 하려다 보니 DOM 요소를 탐색하는 과정에서 `as`를 사용한 타입 단언이 필요했고, 특정 케이스(`quotes`)를 처리하는 로직이 다소 선언적이지 못하게 구현되었습니다. 이 부분은 추후 더 타입 안전하면서도 깔끔한 구조로 개선할 수 있을지 지속적으로 고민해볼 예정입니다.